### PR TITLE
Add pre-push hook to block direct pushes to main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Pre-push hook to prevent direct pushes to main branch
+# Override with: FORCE_PUSH_MAIN=1 git push
+
+protected_branch="main"
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [[ "$remote_ref" == *"$protected_branch"* ]]; then
+    if [[ "$FORCE_PUSH_MAIN" != "1" ]]; then
+      echo ""
+      echo "🚫 Direct push to '$protected_branch' is blocked."
+      echo ""
+      echo "Please create a pull request instead:"
+      echo "  git checkout -b feature/my-branch"
+      echo "  git push -u origin feature/my-branch"
+      echo "  gh pr create"
+      echo ""
+      echo "To bypass (admin only):"
+      echo "  FORCE_PUSH_MAIN=1 git push"
+      echo ""
+      exit 1
+    else
+      echo "⚠️  Bypassing branch protection (FORCE_PUSH_MAIN=1)"
+    fi
+  fi
+done
+
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Configure git to use .githooks directory for hooks
+# Run this after cloning the repository
+
+git config core.hooksPath .githooks
+echo "✅ Git hooks configured to use .githooks directory"


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-push` to prevent direct pushes to main
- Add `scripts/setup-hooks.sh` to configure git hooks after cloning

## Setup
After cloning, run:
```bash
./scripts/setup-hooks.sh
```

## Bypass
Admins can bypass with:
```bash
FORCE_PUSH_MAIN=1 git push
```