### PR TITLE
Remove beads (bd) integration from speckit workflow

### DIFF
--- a/.claude/commands/speckit.taskstoissues.md
+++ b/.claude/commands/speckit.taskstoissues.md
@@ -1,5 +1,5 @@
 ---
-description: Convert existing tasks into a two-tier issue system - high-level GitHub issues as parents with detailed beads (bd) issues as children.
+description: Convert existing tasks into GitHub issues with checklists mirroring tasks.md for high-level tracking.
 tools: ['github/github-mcp-server/issue_write']
 ---
 
@@ -13,12 +13,12 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Overview
 
-This command creates a two-tier issue tracking system:
+This command creates GitHub issues from tasks.md for high-level tracking:
 
-- **GitHub Issues**: High-level parent issues for phases/features (e.g., "Phase 3: Implement User Interface for AI Chat")
-- **Beads Issues**: Detailed, actionable tasks tracked locally with `bd`
+- **GitHub Issues**: High-level issues for phases/features with task checklists
+- **tasks.md**: Source of truth for detailed task tracking (using `- [ ]` / `- [x]`)
 
-Each GitHub issue contains a checklist of bd tasks showing their complete/incomplete status.
+Each GitHub issue contains a checklist mirroring the tasks in tasks.md.
 
 ## Outline
 
@@ -46,30 +46,20 @@ git config --get remote.origin.url
      - ## Overview section with feature/phase description
      - ## Tasks section with FULL checklist of all individual tasks
      - Each task in format: `- [ ] T### [P] [tags] Task title with full description`
-     - **Status:** `X/Y tasks completed` (with ✅ if all complete)
-     - ## Local Task Tracking section with bd commands
+     - **Status:** `X/Y tasks completed` (with checkmark emoji if all complete)
+     - ## Task Tracking section explaining that tasks.md is the source of truth
    - Labels: Add appropriate labels (phase, feature, etc.) if available
 
-6. **For each individual task**, create a bd issue:
-
-   ```bash
-   bd create "Task title" --json --priority <0-4> --type <task|bug|feature>
-   ```
-
-   - Parse the JSON output to get the issue ID (e.g., `memoryloop-1`)
-   - Store the mapping between task number and bd issue ID
-
-7. **Checklist format requirements:**
+6. **Checklist format requirements:**
    - Use `- [ ]` for incomplete tasks and `- [x]` for completed tasks
    - Include task number: `T001`, `T032`, etc.
    - Include all tags from original task: `[P]` for parallel, `[US1]` for user story
    - Include full task description with file paths when relevant
    - Example: `- [ ] T032 [P] [US1] Contract test for POST /api/auth/signin in tests/contract/auth.test.ts`
 
-8. **Output summary**:
+7. **Output summary**:
    - Total GitHub issues created
-   - Total bd issues created
-   - Mapping of GitHub issues to bd issue ranges
+   - Mapping of GitHub issues to task ranges
 
 ## Example Output
 
@@ -94,14 +84,14 @@ Implement user authentication system with login, signup, and session management.
 
 **Status:** 0/5 tasks completed
 
-## Local Task Tracking
+## Task Tracking
 
-These tasks are tracked locally with beads. Run:
+Tasks are tracked in `specs/[feature]/tasks.md`. Update task status there:
 
-- `bd list` - View all tasks
-- `bd ready` - View ready-to-work tasks
-- `bd show memoryloop-<id>` - View task details
-- `bd update memoryloop-<id> --status in_progress` - Claim a task
+- `- [ ]` for incomplete tasks
+- `- [x]` for completed tasks
+
+Sync GitHub issue checklists when tasks are completed.
 ```
 
 **Labels:** phase-3, user-story-1, authentication
@@ -110,11 +100,10 @@ These tasks are tracked locally with beads. Run:
 
 > [!IMPORTANT]
 >
-> - GitHub issues are **high-level tracking** only - don't create individual GitHub issues for each task
-> - Beads (bd) issues are the **source of truth** for task details and status
-> - Update GitHub issue checklists when bd tasks are completed
-> - Use `bd create` with `--json` flag for programmatic output
-> - All bd issues are automatically tracked in `.beads/issues.jsonl` and synced with git
+> - GitHub issues are **high-level tracking** for visibility
+> - `tasks.md` is the **source of truth** for task details and status
+> - Update GitHub issue checklists when tasks in tasks.md are completed
+> - Use standard markdown checkbox syntax in tasks.md
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE GITHUB ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL

--- a/specs/006-remove-bd/checklists/requirements.md
+++ b/specs/006-remove-bd/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Remove Beads (bd) Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.plan` or direct implementation
+- This is a straightforward cleanup task with well-defined scope

--- a/specs/006-remove-bd/plan.md
+++ b/specs/006-remove-bd/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: Remove Beads (bd) Integration
+
+**Branch**: `006-remove-bd` | **Date**: 2025-12-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/006-remove-bd/spec.md`
+
+## Summary
+
+Remove the beads (bd) task tracking tool from the project, consolidating all task management to use `specs/[feature]/tasks.md` files with markdown checkboxes. This involves uninstalling the bd package, removing the .beads directory, and updating the `speckit.taskstoissues.md` command to reference only GitHub Issues and tasks.md.
+
+## Technical Context
+
+**Language/Version**: TypeScript/Node.js (existing project)
+**Primary Dependencies**: N/A (removing a dependency, not adding)
+**Storage**: N/A (file system operations only)
+**Testing**: Manual verification (grep for references, check package.json)
+**Target Platform**: Development tooling (cross-platform)
+**Project Type**: Web application (Next.js)
+**Performance Goals**: N/A (no runtime impact)
+**Constraints**: N/A
+**Scale/Scope**: Small cleanup task affecting ~2 files
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Documentation-First | PASS | Spec complete with user stories and acceptance criteria |
+| II. Test-First (TDD) | N/A | No runtime code; verification via grep/inspection |
+| III. Modularity | PASS | Isolated change to tooling configuration |
+| IV. Simplicity (YAGNI) | PASS | Removing complexity, not adding |
+| V. Observability | N/A | No runtime behavior |
+| VI. Atomic Commits | PASS | Will follow .claude/rules.md |
+
+**Gate Status**: PASS - No violations. Proceed to implementation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-remove-bd/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── checklists/          # Quality checklists
+│   └── requirements.md  # Spec quality validation
+└── tasks.md             # Task tracking (to be created)
+```
+
+### Files to Modify
+
+```text
+.claude/commands/
+└── speckit.taskstoissues.md  # Update to remove bd references
+
+package.json                   # Remove bd dependency (if present)
+package-lock.json              # Updated after npm install
+
+.beads/                        # Directory to delete (if exists)
+```
+
+**Structure Decision**: No new directories or code files. This is a cleanup operation modifying existing configuration files.
+
+## Complexity Tracking
+
+> No complexity violations. This feature reduces complexity.
+
+## Phase 0: Research
+
+This feature requires no research. It is a straightforward removal of:
+1. A npm package (bd/beads) from dependencies
+2. A configuration directory (.beads)
+3. References in a command file (speckit.taskstoissues.md)
+
+**Research Status**: COMPLETE (no unknowns)
+
+## Phase 1: Design
+
+### Changes Required
+
+#### 1. Check and Remove bd Package
+
+```bash
+# Check if bd exists in package.json
+grep -E "\"bd\"|\"beads\"" package.json
+
+# If found, remove it
+npm uninstall bd  # or beads, depending on package name
+```
+
+#### 2. Remove .beads Directory
+
+```bash
+# Check if directory exists
+ls -la .beads/
+
+# If exists, remove it
+rm -rf .beads/
+```
+
+#### 3. Update speckit.taskstoissues.md
+
+The command file needs to be rewritten to:
+- Remove all bd/beads CLI references
+- Keep GitHub Issues integration
+- Reference tasks.md for task tracking
+- Simplify the two-tier system to: GitHub Issues (high-level) + tasks.md (detailed)
+
+### Updated Command Structure
+
+The new `speckit.taskstoissues.md` should:
+1. Read tasks from `specs/[feature]/tasks.md`
+2. Group tasks into high-level GitHub Issues (by phase/user story)
+3. Each GitHub Issue contains a checklist mirroring tasks.md
+4. No bd commands, no .beads references
+
+## Verification Checklist
+
+After implementation, verify:
+
+- [ ] `grep -r "bd" .claude/commands/` returns no matches (except this plan reference)
+- [ ] `grep -r "beads" .claude/commands/` returns no matches
+- [ ] `ls .beads` returns "No such file or directory"
+- [ ] `grep -E "\"bd\"|\"beads\"" package.json` returns no matches
+- [ ] `speckit.taskstoissues.md` references only GitHub Issues and tasks.md

--- a/specs/006-remove-bd/spec.md
+++ b/specs/006-remove-bd/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Remove Beads (bd) Integration
+
+**Feature Branch**: `006-remove-bd`
+**Created**: 2025-12-21
+**Status**: Draft
+**Input**: User description: "Remove bd integration completely. Uninstall library, update all files in .claude/commands where we mention bd. We want to use tasks.md inside each feature's spec folder to keep track of tasks."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Simplified Task Tracking (Priority: P1)
+
+As a developer, I want all task tracking to happen in a single location (`specs/[feature]/tasks.md`) so that I don't need to manage multiple systems or install additional tools.
+
+**Why this priority**: This is the core value proposition - eliminating complexity by removing an unnecessary layer of tooling and consolidating task tracking.
+
+**Independent Test**: Can be fully tested by verifying that all task management happens through tasks.md files and no bd commands are required or referenced.
+
+**Acceptance Scenarios**:
+
+1. **Given** a feature with tasks defined, **When** I want to track progress, **Then** I can do so entirely through the tasks.md file using checkbox syntax (`- [ ]` / `- [x]`)
+2. **Given** the codebase after this change, **When** I search for bd or beads references, **Then** no functional references exist in command files
+3. **Given** a new clone of the repository, **When** I start working on features, **Then** I do not need to install any additional task tracking tools
+
+---
+
+### User Story 2 - Clean Uninstallation (Priority: P2)
+
+As a developer, I want all traces of the bd library removed from the project so that there are no orphaned dependencies or configuration files.
+
+**Why this priority**: Ensures a clean codebase without leftover artifacts that could cause confusion.
+
+**Independent Test**: Can be tested by verifying no bd-related packages exist in package.json and no .beads directory exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current project with bd installed, **When** the removal is complete, **Then** no bd-related entries exist in package.json or package-lock.json
+2. **Given** the project root, **When** I check for .beads directory, **Then** it does not exist
+3. **Given** the project, **When** I run `npm install`, **Then** no bd-related packages are installed
+
+---
+
+### User Story 3 - Updated Documentation (Priority: P3)
+
+As a developer using speckit commands, I want all command documentation to reflect the simplified task tracking approach so that instructions are accurate and don't reference removed tools.
+
+**Why this priority**: Documentation accuracy is important but secondary to functional changes.
+
+**Independent Test**: Can be tested by reviewing all .claude/commands files and verifying no bd references exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** the speckit.taskstoissues.md command, **When** I read it, **Then** it only references GitHub Issues and tasks.md (no bd mentions)
+2. **Given** any .claude/commands file, **When** I search for "bd" or "beads", **Then** no matches are found
+
+---
+
+### Edge Cases
+
+- What happens if .beads directory doesn't exist? No action needed, skip gracefully
+- What happens if bd is not in package.json? No action needed, skip gracefully
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST remove all bd/beads package references from package.json
+- **FR-002**: System MUST remove .beads directory if it exists
+- **FR-003**: System MUST update speckit.taskstoissues.md to use only GitHub Issues and tasks.md for tracking
+- **FR-004**: System MUST ensure no .claude/commands files reference bd or beads tools
+- **FR-005**: Task tracking MUST be consolidated to use `specs/[feature]/tasks.md` with markdown checkboxes
+
+### Key Entities
+
+- **tasks.md**: Markdown file containing task checkboxes, located at `specs/[feature-name]/tasks.md`
+- **GitHub Issues**: High-level feature/milestone tracking (optional, for visibility)
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Zero references to "bd" or "beads" exist in .claude/commands directory
+- **SC-002**: No bd-related packages exist in package.json dependencies
+- **SC-003**: No .beads directory exists in project root
+- **SC-004**: All task tracking can be performed using only tasks.md files and standard git operations
+- **SC-005**: New contributors can start working without installing any task tracking tools beyond git
+
+## Assumptions
+
+- The bd library was installed as a dev dependency (if at all)
+- The .beads directory may or may not exist depending on prior usage
+- GitHub Issues integration for high-level tracking remains useful and should be preserved
+- The speckit.taskstoissues.md command should be updated rather than deleted, as GitHub Issues tracking is still valuable

--- a/specs/006-remove-bd/tasks.md
+++ b/specs/006-remove-bd/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Remove Beads (bd) Integration
+
+**Input**: Design documents from `/specs/006-remove-bd/`
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: Not applicable - this is a cleanup task with manual verification.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify current state before making changes
+
+- [x] T001 Check if bd/beads package exists in package.json
+- [x] T002 Check if .beads directory exists at project root
+
+---
+
+## Phase 2: User Story 1 - Simplified Task Tracking (Priority: P1) 🎯 MVP
+
+**Goal**: Ensure all task tracking uses tasks.md files with no bd dependencies
+
+**Independent Test**: Search for bd/beads references returns no matches in .claude/commands
+
+### Implementation for User Story 1
+
+- [x] T003 [US1] Rewrite .claude/commands/speckit.taskstoissues.md to remove all bd/beads references and use only GitHub Issues + tasks.md
+
+**Checkpoint**: speckit.taskstoissues.md should reference only GitHub Issues and tasks.md
+
+---
+
+## Phase 3: User Story 2 - Clean Uninstallation (Priority: P2)
+
+**Goal**: Remove all bd library traces from the project
+
+**Independent Test**: No bd package in package.json, no .beads directory exists
+
+### Implementation for User Story 2
+
+- [x] T004 [P] [US2] Remove bd/beads package from package.json (if present) using npm uninstall
+- [x] T005 [P] [US2] Remove .beads directory from project root (if exists)
+
+**Checkpoint**: No bd artifacts remain in the project
+
+---
+
+## Phase 4: User Story 3 - Updated Documentation (Priority: P3)
+
+**Goal**: Verify all command documentation is accurate
+
+**Independent Test**: grep for bd/beads in .claude/commands returns no matches
+
+### Implementation for User Story 3
+
+- [x] T006 [US3] Verify no other .claude/commands files reference bd or beads (scan and fix if needed)
+
+**Checkpoint**: All documentation accurately reflects tasks.md-only workflow
+
+---
+
+## Phase 5: Verification
+
+**Purpose**: Confirm all success criteria are met
+
+- [x] T007 Run `grep -r "bd" .claude/commands/` and verify no functional matches
+- [x] T008 Run `grep -r "beads" .claude/commands/` and verify no matches
+- [x] T009 Verify .beads directory does not exist
+- [x] T010 Verify no bd-related packages in package.json
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **User Story 1 (Phase 2)**: Can start after Setup
+- **User Story 2 (Phase 3)**: Can start after Setup, parallel with US1
+- **User Story 3 (Phase 4)**: Depends on US1 completion (need updated file to verify)
+- **Verification (Phase 5)**: Depends on all user stories complete
+
+### Parallel Opportunities
+
+- T004 and T005 can run in parallel (different targets)
+- US1 and US2 can run in parallel (independent changes)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: User Story 1 (T003)
+3. **STOP and VALIDATE**: Verify speckit.taskstoissues.md is updated
+4. Commit changes
+
+### Full Implementation
+
+1. Setup → US1 → US2 → US3 → Verification
+2. Each user story is a separate commit following .claude/rules.md
+
+---
+
+## Notes
+
+- This is a cleanup task, not new feature development
+- No tests needed - verification is via grep/inspection
+- Edge cases (missing .beads, no bd in package.json) are handled gracefully
+- Commit after each user story phase


### PR DESCRIPTION
## Summary

Remove the beads (bd) task tracking tool and consolidate task management to use `specs/[feature]/tasks.md` files with markdown checkboxes.

Closes #163

## Changes

- Updated `.claude/commands/speckit.taskstoissues.md` to use only GitHub Issues + tasks.md
- Removed all bd CLI command references (`bd create`, `bd list`, `bd show`, etc.)
- Added feature spec, plan, and tasks documentation in `specs/006-remove-bd/`

## Test plan

- [x] `grep -r "bd" .claude/commands/` returns no matches
- [x] `grep -r "beads" .claude/commands/` returns no matches
- [x] No .beads directory exists
- [x] No bd packages in package.json