### PR TITLE
Hotfix: Add missing status column to init-db.sql

### DIFF
--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS flashcards (
   skill_node_id UUID,
   card_type VARCHAR(20) NOT NULL DEFAULT 'flashcard',
   card_metadata JSONB,
+  status VARCHAR(20) NOT NULL DEFAULT 'active',
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
@@ -92,6 +93,9 @@ BEGIN
   END IF;
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'flashcards' AND column_name = 'card_metadata') THEN
     ALTER TABLE flashcards ADD COLUMN card_metadata JSONB;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'flashcards' AND column_name = 'status') THEN
+    ALTER TABLE flashcards ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'active';
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
Fixes production error where goals fail to load due to missing `status` column in flashcards table.

**Root Cause:** When migration `0007_add_flashcard_status.sql` was created, the `scripts/init-db.sql` file (used by Docker entrypoint) was not updated to include the new column.

**Error in production logs:**
```
Failed query: select ... "status" from "flashcards" where ...
```

## Changes
- Added `status VARCHAR(20) NOT NULL DEFAULT 'active'` to flashcards CREATE TABLE
- Added conditional ALTER TABLE to add column for existing deployments

## Test plan
- [x] All tests pass (423 tests)
- [ ] Deploy and verify goals load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)