### PR TITLE
Drop deprecated tables and columns for v2 pivot

### DIFF
--- a/drizzle/0010_drop_deprecated_tables.md
+++ b/drizzle/0010_drop_deprecated_tables.md
@@ -1,0 +1,70 @@
+# Migration 0010: Drop Deprecated Tables
+
+**Date**: 2026-01-02
+**Feature**: Cleanup from v2 pivot to goal-based learning
+**Related Issues**: #227, #229, #251, #258
+
+## Summary
+
+This migration removes deprecated database tables and columns that were part of the chat-based and deck-based features in v1. These features were replaced by the goal-based learning system introduced in the v2 pivot.
+
+## Tables Dropped
+
+1. **deck_cards** - Junction table linking decks to flashcards
+2. **decks** - User-created flashcard decks
+3. **messages** - Chat messages (had embeddings for semantic search)
+4. **conversations** - Chat conversation threads
+
+## Columns Dropped from flashcards table
+
+- `conversation_id` - Foreign key to conversations table
+- `message_id` - Foreign key to messages table
+
+## Migration Steps
+
+The migration follows this order to respect foreign key constraints:
+
+1. Drop FK constraints from flashcards to conversations and messages
+2. Drop conversation_id and message_id columns from flashcards
+3. Drop deck_cards (junction table - references decks and flashcards)
+4. Drop decks table
+5. Drop messages (references conversations)
+6. Drop conversations
+
+All operations use `IF EXISTS` and `CASCADE` to safely handle different database states.
+
+## Safety Notes
+
+- Uses `IF EXISTS` to allow idempotent execution
+- Uses `CASCADE` to automatically drop dependent objects (indexes, etc.)
+- Foreign key constraints are explicitly dropped first to avoid issues
+- Safe to run on production as data in these tables is no longer used
+
+## Rollback
+
+If rollback is needed, you would need to:
+
+1. Recreate the tables using migrations 0003 and 0004 as reference
+2. Re-add the columns to flashcards table
+3. Re-add foreign key constraints
+
+**Note**: Data in these tables cannot be recovered after this migration runs.
+
+## Testing
+
+Before running on production:
+
+1. Verify no application code references these tables
+2. Verify no foreign keys from other tables reference these tables
+3. Test on a staging database first
+4. Backup production database before running
+
+## Application Impact
+
+**No application impact** - these tables were already removed from:
+
+- Schema definitions (`lib/db/drizzle-schema.ts`) in PR #258
+- All application code
+- All API endpoints
+
+This migration simply cleans up the database to match the current schema.

--- a/drizzle/0010_drop_deprecated_tables.sql
+++ b/drizzle/0010_drop_deprecated_tables.sql
@@ -1,0 +1,25 @@
+-- Drop deprecated tables and columns from v2 pivot to goal-based learning
+-- See issues #227, #229, #251
+-- These tables were part of the chat and deck features that are no longer used
+
+-- Step 1: Drop foreign key constraints on flashcards table
+ALTER TABLE "flashcards" DROP CONSTRAINT IF EXISTS "flashcards_conversation_id_conversations_id_fk";
+ALTER TABLE "flashcards" DROP CONSTRAINT IF EXISTS "flashcards_message_id_messages_id_fk";
+
+-- Step 2: Drop deprecated columns from flashcards table
+ALTER TABLE "flashcards" DROP COLUMN IF EXISTS "conversation_id";
+ALTER TABLE "flashcards" DROP COLUMN IF EXISTS "message_id";
+
+-- Step 3: Drop deck_cards junction table (must be before decks due to FK)
+DROP TABLE IF EXISTS "deck_cards" CASCADE;
+
+-- Step 4: Drop decks table
+DROP TABLE IF EXISTS "decks" CASCADE;
+
+-- Step 5: Drop messages table (must be before conversations due to FK)
+DROP TABLE IF EXISTS "messages" CASCADE;
+
+-- Step 6: Drop conversations table
+DROP TABLE IF EXISTS "conversations" CASCADE;
+
+-- Note: Indexes on the dropped tables will be automatically dropped by CASCADE

--- a/drizzle/MIGRATION_0010_GUIDE.md
+++ b/drizzle/MIGRATION_0010_GUIDE.md
@@ -1,0 +1,75 @@
+# Running Migration 0010
+
+## Quick Start
+
+```bash
+# Run the migration
+npm run db:migrate
+```
+
+## Pre-Migration Checklist
+
+- [ ] Backup production database
+- [ ] Verify no code references deprecated tables (conversations, messages, decks, deck_cards)
+- [ ] Test on staging environment first
+- [ ] Review migration file: `drizzle/0010_drop_deprecated_tables.sql`
+- [ ] Review documentation: `drizzle/0010_drop_deprecated_tables.md`
+
+## What This Migration Does
+
+Removes deprecated tables from the v1 chat-based and deck-based features:
+
+- Drops `conversation_id` and `message_id` columns from `flashcards` table
+- Drops `deck_cards` table (junction table)
+- Drops `decks` table
+- Drops `messages` table
+- Drops `conversations` table
+
+## Verification After Migration
+
+```sql
+-- Verify flashcards table no longer has conversation_id or message_id
+SELECT column_name
+FROM information_schema.columns
+WHERE table_name = 'flashcards'
+  AND column_name IN ('conversation_id', 'message_id');
+-- Should return 0 rows
+
+-- Verify deprecated tables are gone
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN ('conversations', 'messages', 'decks', 'deck_cards');
+-- Should return 0 rows
+
+-- Verify flashcards table still works
+SELECT COUNT(*) FROM flashcards;
+-- Should return count without errors
+```
+
+## Rollback (if needed)
+
+**WARNING**: Rollback will NOT restore data. Only recreate empty tables.
+
+```sql
+-- This would require recreating tables from migrations 0003 and 0004
+-- Data cannot be recovered
+-- Only use if absolutely necessary
+```
+
+## Support
+
+If issues occur:
+
+1. Check logs: `docker-compose logs postgres`
+2. Verify migration status: `SELECT * FROM __drizzle_migrations;`
+3. Contact database administrator
+4. Do NOT attempt manual rollback without backup
+
+## Related Files
+
+- Migration SQL: `/Users/nick/Code/memoryloop/drizzle/0010_drop_deprecated_tables.sql`
+- Documentation: `/Users/nick/Code/memoryloop/drizzle/0010_drop_deprecated_tables.md`
+- Schema: `/Users/nick/Code/memoryloop/lib/db/drizzle-schema.ts`
+- Related PR: #258
+- Related Issues: #227, #229, #251

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,20 @@
       "when": 1735536000000,
       "tag": "0008_add_distractors",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1735617600000,
+      "tag": "0009_add_background_jobs",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1735862400000,
+      "tag": "0010_drop_deprecated_tables",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Migration 0010 removes deprecated database tables and columns that are no longer used after the v2 pivot to goal-based learning.

**Tables dropped:**
- conversations
- messages  
- decks
- deck_cards

**Columns dropped from flashcards:**
- conversation_id
- message_id

This migration cleans up the database schema to match the current application code (PR #258).

## Files

- `drizzle/0010_drop_deprecated_tables.sql` - Migration SQL
- `drizzle/0010_drop_deprecated_tables.md` - Migration documentation
- `drizzle/MIGRATION_0010_GUIDE.md` - Migration guide with testing and rollback instructions

## Testing

All unit tests pass. Migration uses `IF EXISTS` and `CASCADE` for safe execution. Ready for staging/production deployment.

## Related Issues

Closes #227, #229, #251, #258

Co-Authored-By: Claude <noreply@anthropic.com>