### PR TITLE
Fix: Reset failed flashcard generation jobs from missing handler

### DIFF
--- a/app/api/goals/[goalId]/flashcard-jobs/route.ts
+++ b/app/api/goals/[goalId]/flashcard-jobs/route.ts
@@ -15,7 +15,10 @@ import { getDb } from '@/lib/db/pg-client'
 import { backgroundJobs, skillNodes } from '@/lib/db/drizzle-schema'
 import { eq, and, sql } from 'drizzle-orm'
 import { processJob, canProcessJob } from '@/lib/jobs/processor'
-import { resetStaleJobs } from '@/lib/db/operations/background-jobs'
+import {
+  resetStaleJobs,
+  resetFailedJobsForMissingHandler,
+} from '@/lib/db/operations/background-jobs'
 import * as logger from '@/lib/logger'
 
 // Register job handlers (side-effect import)
@@ -58,8 +61,9 @@ export async function GET(_request: Request, context: RouteContext) {
       })
     }
 
-    // Reset stale jobs first
+    // Reset stale jobs and failed jobs from missing handler
     await resetStaleJobs()
+    await resetFailedJobsForMissingHandler('flashcard_generation')
 
     const db = getDb()
 


### PR DESCRIPTION
## Summary
- Bug: Old flashcard_generation jobs failed with "Unknown job type" error before the handler was created
- These jobs are stuck in 'failed' status and won't retry
- Solution: Added function to reset failed jobs with this specific error, called when polling for flashcard jobs
- This allows stuck jobs to be reprocessed with the new handler

## Test plan
- Manual testing: Verify that previously stuck flashcard jobs with "Unknown job type" error are reset and processed correctly
- Confirm that the reset only affects jobs with the specific error message
- Check logs to ensure jobs transition from 'failed' to 'processing' status