### PR TITLE
Update email queue cron comment to remove Vercel reference

### DIFF
--- a/app/api/cron/process-email-queue/route.ts
+++ b/app/api/cron/process-email-queue/route.ts
@@ -4,8 +4,8 @@
  * Background job to process queued emails
  *
  * Should be called periodically by:
- * - Vercel Cron (for production deployments)
- * - GitHub Actions workflow (scheduled)
+ * - GitHub Actions workflow (scheduled every 5 minutes)
+ * - System cron job on the server
  * - Manual curl/fetch during development
  *
  * Security: Use CRON_SECRET env var to authenticate requests


### PR DESCRIPTION
## Summary
This is a comment-only change that clarifies the email queue cron job implementation. The comment was updated to remove a Vercel-specific reference that was no longer accurate.

## Test plan
- All existing unit tests pass
- Pre-push checks (linting, formatting, tests) pass