### PR TITLE
Fix deploy script data directory permissions

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -27,6 +27,15 @@ fi
 echo "Pulling image..."
 docker pull "${IMAGE_NAME}"
 
+# Ensure data directories exist with correct permissions
+echo "Ensuring data directories have correct permissions..."
+mkdir -p "${DEPLOY_DIR}/data/postgres"
+mkdir -p "${DEPLOY_DIR}/data/lancedb"
+# PostgreSQL runs as uid 70 in alpine image
+chown -R 70:70 "${DEPLOY_DIR}/data/postgres"
+# Next.js app runs as uid 1001 (nextjs user)
+chown -R 1001:1001 "${DEPLOY_DIR}/data/lancedb"
+
 # Create backup of current state
 BACKUP_TAG="backup-$(date +%Y%m%d-%H%M%S)"
 if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "loopi-backup"; then


### PR DESCRIPTION
## Summary
Fixes CI deploy failures caused by incorrect file permissions on data directories.

### Problem
- PostgreSQL data at `/opt/loopi/data/postgres` needs uid 70 ownership
- LanceDB data at `/opt/loopi/data/lancedb` needs uid 1001 ownership
- After data migrations or fresh deploys, permissions were incorrect causing container startup failures

### Solution
- Added permission setup step in deploy.sh before container startup
- Creates directories if missing
- Sets correct ownership for both postgres (70:70) and lancedb (1001:1001)

## Test plan
- [x] Verified fix resolves health check failures on VPS
- [ ] CI deploy should pass after merge