### PR TITLE
Fix deploy: stop containers before permission changes

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,10 +31,14 @@ docker pull "${IMAGE_NAME}"
 echo "Ensuring data directories have correct permissions..."
 mkdir -p "${DEPLOY_DIR}/data/postgres"
 mkdir -p "${DEPLOY_DIR}/data/lancedb"
+# Stop containers before fixing permissions (files may be locked)
+echo "Stopping containers for permission fix..."
+docker compose -f "${COMPOSE_FILE}" stop 2>/dev/null || true
+
 # PostgreSQL runs as uid 70 in alpine image
-chown -R 70:70 "${DEPLOY_DIR}/data/postgres"
+chown -R 70:70 "${DEPLOY_DIR}/data/postgres" 2>/dev/null || true
 # Next.js app runs as uid 1001 (nextjs user)
-chown -R 1001:1001 "${DEPLOY_DIR}/data/lancedb"
+chown -R 1001:1001 "${DEPLOY_DIR}/data/lancedb" 2>/dev/null || true
 
 # Create backup of current state
 BACKUP_TAG="backup-$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
## Summary
Follow-up fix for #300. The chown commands were failing because containers were still running with files locked.

### Changes
- Stop all containers before running chown
- Add `|| true` to chown commands as fallback

## Test plan
- [ ] CI deploy should pass after merge